### PR TITLE
Use git alias instead of gitalias

### DIFF
--- a/shgit.sh
+++ b/shgit.sh
@@ -104,7 +104,7 @@ eval "$(
     do
       if expr -- "$command" : '!' >/dev/null
       then echo "alias $key='git $key'"
-      else echo "gitalias $key=\"git $command\""
+      else echo "git alias $key=\"git $command\""
       fi
     done
   )"


### PR DESCRIPTION
The latter doesn't work on my system. Ubuntu proposes to install the `git-extras` package to have `git-alias` available, but `git alias` works for me out of the box.